### PR TITLE
Add classes, enums, pattern matching, error throwing, while loops, function returns, `break` and `continue`, bitwise operations under the `math` library, and the new `push` and `pop` functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules
-*.bsx
-*.bs
 dist/**

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ An esoteric programming language, in TypeScript for heaven's sake.
 # Running
 - To run a specific file: `npm run bussin <FILENAME>`
 - To run in repl mode (Bussin only): `npm run bussin`
+- To view the AST of a specific file: `npm run bussin view-ast <FILENAME>`
+- To transform a .bsx file to a .bs file (to make it more readable): `npm run bussin unbeautify <FILENAME>`
 
 # Bussin
-You can find an example at `/examples/main.bs`
+You can find an example at `/examples/main.bs`, amongst many others.
 
 # Bussin X 🚀
 We, at Bussin, believe everyone should be entertained while coding. Meet our alternative: **.bsx**.
@@ -15,12 +17,46 @@ We, at Bussin, believe everyone should be entertained while coding. Meet our alt
 Inside **Bussin X**, you *can* use BS syntax, however, it's recommended to use the **BSX** syntax described below. 
 
 ### New!
-- Updated fetch. `fetch("https://example.com/")(bruh(data) { waffle(data) })`
-- Bussin Object Notation 🗣️💯🔥. `bson.parse("[1, 2, 3]")`, `bson.stringify([1, 2, 3])`
-- Websockets. `lit ws be websocket("wss://thissiteis.fake/?EIO=4&transport=websocket") rn`, `ws.send("Bussin X")`
-- Math number stuff. `math.e`, `parseNumber("5")`
-- More string functions. `trim("  Hello  ")`, `splitstr("Hello,There", ",")`
-- Comments. `lit x be 5 + 10 rn /* this code is bussin */`
+- [Match expressions](#pattern-matching)
+- [Enums](#enums): `baller Foo {}`, `Foo.Bar`, `Foo.Bar(69)`
+- [Classes](#classes)
+- Throwing errors: `yeet "error"`
+- While loops: `diddy(nocap) {}`
+- Returning from functions: `ghost value`
+- Breaking from loops: `aura`
+- Continuing from loops: `gyatt`
+
+## Table of Contents
+**↑ Less advanced**\
+**↓ More advanced**
+
+- [Learn about commenting your code](#comments)
+- [Learn about exiting the program](#exit)
+- [Learn about Bussin X's basic data structures](#data-strucutres)
+    - [Learn about strings](#strings)
+    - [Learn about numbers](#numbers)
+    - [Learn about booleans](#booleans)
+    - [Learn about `null`](#null)
+    - [Learn about arrays](#arrays)
+    - [Learn about objects](#objects)
+- [Learn about variables](#variables)
+- [Learn about our math capabilities](#math)
+- [Learn about our time capabilities](#time)
+- [Learn about taking user input](#user-input)
+- [Learn about importing from other files](#importing)
+- [Learn about conditionals with `if`](#if-statements)
+- [Learn about the ternary operator](#ternary)
+- [Learn about loops](#loops)
+- [Learn about errors and how to avoid them safely](#try-catch)
+- [Learn about functions](#functions)
+- [Learn about enums](#enums)
+- [Learn about classes](#classes)
+- [Learn about pattern matching](#pattern-matching)
+- [Learn about BSON](#bson)
+- [Learn about fetching from domains](#fetch)
+- [Learn about regular expressions](#regex)
+- [Learn about websockets](#websockets)
+- [Learn about types](#types)
 
 ## Variables
 Mutable variables are created with:
@@ -123,6 +159,76 @@ multi line
 */
 ```
 
+## Classes
+Wait, what do you mean "class"? Here at Bussin X, we identify classes as chads.
+```rs
+chad Gigachad {
+    funny_powder_count rn
+    kai cenat is_the_greatest be nocap rn
+
+    skibidi toilet() {
+        drake.funny_powder_count be 0 rn
+    }
+
+    go_to_the_hood() {
+        drake.funny_powder_count be 999999999999999999 rn
+    }
+}
+```
+Static fields and methods are possible with the `kai cenat` keyword.\
+The constructor is called `skibidi toilet`, which is one of the greatest cinemas produced to this day.\
+In chad methods, you can reference the chad instance with `drake` instead of `this`.
+
+If you were ever thinking about instantiating a chad--I know, a rare occassion--there's a simple solution.\
+Just mog the chad.
+```rs
+mog Gigachad()
+```
+
+## Pattern Matching
+Similar to our try and catch syntax, you can match on something with the `fw` keyword.
+```rs
+lit value be "foo" rn
+fw value {
+    "foo" edges {
+        waffle("bar") rn
+    }
+    put the fries in the bag lil bro edges {
+        waffle(value) rn
+    }
+}
+```
+To match on the default case, use the `put the fries in the bag lil bro` keyword.
+
+## Enums
+We're balling.
+```rs
+baller Bussin {
+    Foo,
+    Bar,
+    Baz,
+    Ballin,
+}
+waffle(Bussin.Ballin) rn // Bussin.Ballin
+```
+We support tagged, enums, too!
+```rs
+waffle(Bussin.Ballin(3)) rn // Bussin.Ballin(3)
+fw Bussin.Ballin(3) {
+    Bussin.Ballin(n) edges {
+        waffle(n) rn // 3
+    }
+    put the fries in the bag lil bro edges {
+        waffle("fuck") rn // This (hopefully) won't print.
+    }
+}
+```
+Here at Bussin X, we believe in simplicity. So, you don't even need to declare enum members. It's optional.
+```rs
+baller Bussin {}
+waffle(Bussin.Ballin) rn // Bussin.Ballin
+```
+
 ## Functions
 Functions in programming are intricate entities that serve as modular units of code designed to perform specific tasks with a high degree of abstraction and reusability. These multifaceted constructs encapsulate a series of instructions, often comprising algorithmic operations and logical conditions, which execute a well-defined purpose within a larger program. Functionality is delineated through a meticulously crafted signature, encompassing parameters and return types, allowing for parameterization and value transmission between the calling code and the function body. The complexity further burgeons as functions may exhibit a plethora of characteristics, including but not limited to recursion, closures, and the ability to manipulate variables within their designated scopes. Their utility extends beyond mere procedural decomposition, often intertwining with the paradigms of object-oriented, functional, or imperative programming, depending on the programming language employed. The orchestration of functions, with their nuanced interplay, results in the orchestration of intricate software systems, promoting maintainability, readability, and the efficient allocation of computational resources. In essence, functions epitomize the sophisticated essence of programming, embodying the elegance and subtlety required to navigate the intricacies of algorithmic design and software engineering. You can create functions by using:
 ```rs
@@ -130,11 +236,17 @@ bruh perform(x, y) {
     x minus y
 }
 ```
-We, at Bussin X, think `return` statements are redundant. Instead, our superior functions return the last value emitted.
+Functions return the last value emitted.
 ```rs
 bruh perform(x, y) {
     x plus y // will do nothing
     x minus y
+}
+```
+You can optionally return values from them, too.
+```rs
+bruh nerd_adddition(x, y) {
+    ghost x plus y rn
 }
 ```
 You can also run the function after a specified timespan:
@@ -171,7 +283,25 @@ Loops in Bussin X are very easy:
 ```rs
 yall(lit i be 0 rn i smol 10 rn i plusplus){}
 ```
-Because we, at Bussin X, believe programmers should be responsible for their code, we did not add any `break` or `continue` keyword functionality to loops.
+You can `break` and `continue` from them normally, with our intuitive keywords:
+```
+yall(lit i be 0 rn i smol 10 rn i plusplus){
+    sus (i fr 9) {
+        aura
+    }
+    gyatt
+}
+```
+We have while loops, too.
+```rs
+lit n be 0 rn
+diddy(nocap) {
+    sus (n smol 10) {
+        aura
+    }
+    n beplus 1 rn
+}
+```
 
 ## Types
 Types in Bussin X are very important!
@@ -202,9 +332,9 @@ yall: number(lit: object i: number be 0: object rn i smol 10 rn i plusplus){
 ## Try Catch
 Bussin X also supports `try` `catch` statements:
 ```rs
-fuck_around {
+fuck around {
     waffle(null plus hogrider)
-} find_out {
+} find out {
     waffle(error)
 }
 ```
@@ -212,7 +342,21 @@ fuck_around {
 Cannot resolve 'hogrider' as it does not exist.
 ```
 
-**Note**: `find_out` doesn't return anything, "error" is a global variable.
+**Note**: `find out` doesn't return anything, "error" is a global variable.
+<br>
+<br>
+<br>
+To throw an error, use the `yeet` keyword.
+```rs
+fuck around {
+    yeet "Bussin X is better"
+} find out {
+    waffle(error)
+}
+```
+```
+Bussin X is better
+```
 
 ## Extra
 ### Math

--- a/examples/classes.bs
+++ b/examples/classes.bs
@@ -1,0 +1,18 @@
+class Apple {
+    static class_name = "Apple";
+    percent;
+
+    constructor() {
+        this.percent = 100;
+    }
+
+    eat() {
+        this.percent -= 1;
+    }
+}
+
+println(Apple.class_name);
+
+let myApple = new Apple();
+myApple.eat();
+println(myApple.percent);

--- a/examples/classes.bsx
+++ b/examples/classes.bsx
@@ -1,0 +1,17 @@
+chad Apple {
+    kai cenat class_name be "Apple" rn
+    percent rn
+
+    skibidi toilet() {
+        drake.percent be 100 rn
+    }
+
+    eat() {
+        drake.percent beminus 1 rn
+    }
+}
+
+waffle(Apple.class_name)
+lit myApple be mog Apple() rn
+myApple.eat() rn
+waffle(myApple.percent) rn

--- a/examples/enums.bs
+++ b/examples/enums.bs
@@ -1,0 +1,23 @@
+enum Foo {
+    Bar,
+    Baz,
+}
+
+let a = Foo.Bar;
+
+match a {
+    Foo.Bar => {
+        println("foo")
+    }
+}
+
+let b = Foo.Baz(2+2)
+
+match b {
+    Foo.Baz(contents) => {
+        println(contents)
+    }
+    default => {
+        println("This shouldn't print.")
+    }
+}

--- a/examples/enums.bsx
+++ b/examples/enums.bsx
@@ -1,0 +1,20 @@
+baller Foo {}
+
+lit a be Foo.Bar rn
+
+fw a {
+    Foo.Bar edges {
+        waffle("foo") rn
+    }
+} rn
+
+lit b be Foo.Bar(2 plus 2) rn
+
+fw b {
+    Foo.Baz(contents) edges {
+        waffle(contents) rn
+    }
+    put the fries in the bag lil bro edges {
+        waffle("on ohio this shouldn't print") rn
+    }
+} rn

--- a/examples/main.bsx
+++ b/examples/main.bsx
@@ -52,17 +52,17 @@ waffle: object(xd: number)
 
 waffle(nerd.random(1,99), nerd.pi)
 
-fuck_around {
+fuck around {
     waffle(haha)
-} find_out {
+} find out {
     waffle(error)
 }
 
-fuck_around {
+fuck around {
     mf res be clapback("ls") rn
 
     waffle(res)
-} find_out {
+} find out {
     waffle(error, "Blud running on windows 💀")
 }
 

--- a/examples/returns.bs
+++ b/examples/returns.bs
@@ -1,0 +1,16 @@
+fn returns() {
+    fn returns2() {
+        if (true) {
+            return 2;
+        }
+        return 3;
+    }
+    let a = returns2();
+    try {
+        return a+2;
+    } catch {
+        return 0;
+    }
+}
+
+println(returns());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bussin",
+  "name": "bussin_fork",
   "version": "1.7",
   "lockfileVersion": 3,
   "requires": true,
@@ -18,13 +18,15 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
-        "@types/node": "^20.9.0",
+        "@types/json-schema": "^7.0.15",
+        "@types/node": "^20.19.0",
         "@types/user-agents": "^1.0.4",
         "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
         "@typescript-eslint/parser": "^7.3.1",
         "eslint": "^8.57.0",
-        "typescript": "^5.2.2"
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -34,6 +36,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -125,6 +140,34 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -160,19 +203,49 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/semver": {
@@ -437,6 +510,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -475,6 +561,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -613,6 +706,13 @@
         "npm": ">=5.x"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -670,6 +770,16 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -1367,6 +1477,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1534,6 +1651,7 @@
       "version": "0.12.7",
       "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
       "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "license": "MIT",
       "dependencies": {
         "process": "^0.11.1",
         "util": "^0.10.3"
@@ -1823,6 +1941,50 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1848,10 +2010,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1861,10 +2024,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -1895,6 +2059,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1949,6 +2120,16 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
     "bussin": "npx ts-node src/main.ts"
   },
   "devDependencies": {
-    "@types/node": "^20.9.0",
+    "@types/json-schema": "^7.0.15",
+    "@types/node": "^20.19.0",
     "@types/user-agents": "^1.0.4",
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "eslint": "^8.57.0",
-    "typescript": "^5.2.2"
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "axios": "^1.6.8",

--- a/showcase/rule110.bsx
+++ b/showcase/rule110.bsx
@@ -1,0 +1,55 @@
+input("Number of generations:")(bruh(genCount) {
+input("Width:")(bruh(width) {
+
+genCount be parseNumber(genCount) rn
+width be parseNumber(width) rn
+
+lit current be [] rn
+yall (lit i be 0 rn i smol width rn i plusplus) {
+    sus (i fr ((width) minus (1))) {
+        push(current, 1)
+    } impostor {
+        push(current, 0)
+    }
+}
+
+bruh tostringGen(gen) {
+    lit buf be "" rn
+    yall (lit i be 0 rn i smol len(gen) rn i plusplus) {
+        sus (gen[i] fr 1) {
+            buf be strcon(buf, "■") rn
+        } impostor {
+            buf be strcon(buf, " ") rn
+        }
+    }
+    strcon(buf, "\n")
+}
+
+bruh nextGen(this) {
+    lit next be [0] rn
+    mf size be len(this) rn
+
+    lit state be nerd.bor(this[0], nerd.blsh(this[1], 1)) rn
+
+    yall (lit i be 0 rn i smol ((size) minus (2)) rn i plusplus) {
+        state be nerd.band(nerd.blsh(state, 1), 7) rn
+        state be nerd.bor(state, ((i plus 2) smol size) then (this[i plus 2]) ornot 0) rn
+        push(next, nerd.band(nerd.brsh(110, state), 1))
+    }
+
+    push(next, 0)
+    next
+}
+
+waffle(tostringGen(current))
+lit buf be "" rn
+yall (lit i be 0 rn i smol genCount rn i plusplus) {
+    current be nextGen(current) rn
+    buf be strcon(buf, tostringGen(current)) rn
+}
+
+waffle(buf)
+
+})
+})
+

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -12,11 +12,21 @@ export type NodeType =
   | "IfStatement"
   | "ForStatement"
   | "TryCatchStatement"
+  | "ThrowStatement"
+  | "ClassDeclaration"
+  | "ClassField"
+  | "ReturnStatement"
+  | "WhileStatement"
+  | "BreakStatement"
+  | "ContinueStatement"
+  | "EnumDeclaration"
 
   // EXPRESSIONS
   | "AssignmentExpr"
   | "MemberExpr"
   | "CallExpr"
+  | "NewExpr"
+  | "MatchExpr"
 
   // LITERALS
   | "Property"
@@ -41,6 +51,45 @@ export interface Stmt {
 export interface Program extends Stmt {
   kind: "Program";
   body: Stmt[];
+}
+
+export interface ThrowStmt extends Stmt {
+  kind: "ThrowStatement";
+  value: Expr;
+}
+
+export interface EnumDeclarationStmt extends Stmt {
+  kind: "EnumDeclaration";
+  members: string[];
+  name: string;
+}
+
+export interface BreakStmt extends Stmt {
+  kind: "BreakStatement";
+}
+
+export interface ContinueStmt extends Stmt {
+  kind: "ContinueStatement";
+}
+
+export interface WhileStmt extends Stmt {
+  kind: "WhileStatement";
+  value: Expr;
+  body: Expr[];
+}
+
+export interface ReturnStmt extends Stmt {
+  kind: "ReturnStatement";
+  value: Expr;
+}
+
+export interface ClassDeclarationStmt extends Stmt {
+  kind: "ClassDeclaration";
+  name: string;
+  fields: Set<string>;
+  staticFields: Map<string, Expr>;
+  funs: Map<string, FunctionDeclaration>;
+  staticFuns: Map<string, FunctionDeclaration>;
 }
 
 export interface VarDeclaration extends Stmt {
@@ -80,6 +129,31 @@ export interface ForStatement extends Stmt {
 
 /**  Expressions will result in a value at runtime unlike Statements */
 export interface Expr extends Stmt {}
+
+/**
+ * Instantiates a given class, calling its constructor if it has one.
+ * You can instantiate on a member expression ("foo.bar") or a regular identifier ("foo").
+ * Example: new Foo(1, 2, 3);
+ */
+export interface NewExpr extends Expr {
+  target: Expr;
+  args: Array<Expr>;
+}
+
+
+/**
+ * Matches on the given value, similar to a switch statement.
+ * You can match on tagged enums with the Enum.Name(variable) syntax, same goes for normal enums.
+ * Multiple matches can be done with the comma operator.
+ * To choose the default case, use the default keyword.
+ * Example: match 3 { 1,2,3 => { true } default => { false } }
+ */
+export interface MatchExpr extends Expr {
+  kind: "MatchExpr";
+  cases: Map<Expr[], Stmt[]>;
+  defaultCase?: Stmt[];
+  value: Expr;
+}
 
 /**
  * A operation with two sides seperated by a operator.

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -75,7 +75,7 @@ export interface ContinueStmt extends Stmt {
 export interface WhileStmt extends Stmt {
   kind: "WhileStatement";
   value: Expr;
-  body: Expr[];
+  body: Stmt[];
 }
 
 export interface ReturnStmt extends Stmt {

--- a/src/frontend/ast.ts
+++ b/src/frontend/ast.ts
@@ -136,6 +136,7 @@ export interface Expr extends Stmt {}
  * Example: new Foo(1, 2, 3);
  */
 export interface NewExpr extends Expr {
+  kind: "NewExpr";
   target: Expr;
   args: Array<Expr>;
 }

--- a/src/frontend/lexer.ts
+++ b/src/frontend/lexer.ts
@@ -17,6 +17,17 @@ export enum TokenType {
     If,
     Else,
     For,
+    Class,
+    Static,
+    Return,
+    Break,
+    Continue,
+    While,
+    New,
+    Enum,
+    Match,
+    Default,
+    Throw,
 
     // Grouping * Operators
     BinaryOperator,
@@ -41,8 +52,9 @@ export enum TokenType {
     Ampersand, // &
     Bar, // |
     Ternary, // ->
+    Arrow, // =>
 
-    EOF, // Signified the end of file.
+    EOF, // Signifies the end of file, equivalent to \0.
     NewLine, // New line
 }
 
@@ -50,12 +62,23 @@ export enum TokenType {
  * Constant lookup for keywords and known identifiers + symbols.
  */
 const KEYWORDS: Record<string, TokenType> = {
-    let: TokenType.Let,
-    const: TokenType.Const,
-    fn: TokenType.Fn,
-    if: TokenType.If,
-    else: TokenType.Else,
-    for: TokenType.For,
+    "let": TokenType.Let,
+    "const": TokenType.Const,
+    "fn": TokenType.Fn,
+    "if": TokenType.If,
+    "else": TokenType.Else,
+    "for": TokenType.For,
+    "class": TokenType.Class,
+    "static": TokenType.Static,
+    "return": TokenType.Return,
+    "break": TokenType.Break,
+    "while": TokenType.While,
+    "continue": TokenType.Continue,
+    "new": TokenType.New,
+    "enum": TokenType.Enum,
+    "match": TokenType.Match,
+    "default": TokenType.Default,
+    "throw": TokenType.Throw,
 };
 
 /**
@@ -126,7 +149,7 @@ function isalpha(src: string, isFirstChar: boolean = false) {
  * Returns true if the character is whitespace like -> [\s, \t, \n]
  */
 function isskippable(str: string) {
-    return str == " " || str == "\n" || str == "\t" || str == '\r';
+    return str == " " || str == "\n" || str == "\t" || str == '\r' || str.charCodeAt(0)==8;
 }
 
 /**
@@ -194,6 +217,9 @@ export function tokenize(sourceCode: string): Token[] {
                     if (src[0] == '=') {
                         src.shift()
                         tokens.push(token('==', TokenType.EqualsCompare));
+                    } else if (src[0]=='>') {
+                        src.shift();
+                        tokens.push(token('=>', TokenType.Arrow));
                     } else {
                         tokens.push(token("=", TokenType.Equals));
                     }

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -69,7 +69,7 @@ export default class Parser {
         const prev = this.eat();
 
         if (!prev || prev.type != type) {
-            console.error(`Parser error: (Ln ${this.lastNonNLLine}, Col ${this.lastNonNLColumn + 1})\n`, err, "Expecting:", type, 'Got:', prev.type);
+            console.error(`Parser error: (Ln ${this.lastNonNLLine}, Col ${this.lastNonNLColumn + 1})\n`, err, "Expecting:", TokenType[type], 'Got:', TokenType[prev.type]);
             process.exit(1)
         }
 

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1,5 +1,5 @@
-import { ClassDeclaration, ReturnStatement, ThrowStatement, WhileStatement } from "typescript";
-import { Stmt, Program, Expr, BinaryExpr, NumericLiteral, Identifier, VarDeclaration, AssignmentExpr, Property, ObjectLiteral, CallExpr, MemberExpr, FunctionDeclaration, StringLiteral, IfStatement, ForStatement, TryCatchStatement, ArrayLiteral, ClassDeclarationStmt, ReturnStmt, NewExpr, WhileStmt, EnumDeclarationStmt, MatchExpr, ThrowStmt } from "./ast";
+import { BreakStatement, ClassDeclaration, ReturnStatement, ThrowStatement, WhileStatement } from "typescript";
+import { Stmt, Program, Expr, BinaryExpr, NumericLiteral, Identifier, VarDeclaration, AssignmentExpr, Property, ObjectLiteral, CallExpr, MemberExpr, FunctionDeclaration, StringLiteral, IfStatement, ForStatement, TryCatchStatement, ArrayLiteral, ClassDeclarationStmt, ReturnStmt, NewExpr, WhileStmt, EnumDeclarationStmt, MatchExpr, ThrowStmt, BreakStmt, ContinueStmt } from "./ast";
 import { tokenize, Token, TokenType } from "./lexer";
 
 export default class Parser {
@@ -123,6 +123,12 @@ export default class Parser {
                 return this.parse_enum_declaration();
             case TokenType.While:
                 return this.parse_while_statement();
+            case TokenType.Break:
+                this.eat();
+                return {kind: "BreakStatement"} as BreakStmt;
+            case TokenType.Continue:
+                this.eat();
+                return {kind: "ContinueStatement"} as ContinueStmt;
             default:
                 return this.parse_expr();
         }

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -97,7 +97,7 @@ export default class Parser {
                 return this.parse_var_declaration();
             case TokenType.Fn: {
                 this.eat(); // eat fn keyword
-                const name = this.at().type == TokenType.Identifier ? this.eat().value : "<anonymous>";
+                const name = this.expect(TokenType.Identifier, "Expected an Identifier for the function name in a function declaration.").value;
                 return this.parse_function_declaration(name);
             }
             case TokenType.Throw: {
@@ -720,6 +720,8 @@ export default class Parser {
                             cases.set(case_arr, body);
                         }
                         defaultCase = body;
+                    } else {
+                        cases.set(case_arr, body);
                     }
                 }
 

--- a/src/frontend/parser.ts
+++ b/src/frontend/parser.ts
@@ -1,4 +1,3 @@
-import { BreakStatement, ClassDeclaration, ReturnStatement, ThrowStatement, WhileStatement } from "typescript";
 import { Stmt, Program, Expr, BinaryExpr, NumericLiteral, Identifier, VarDeclaration, AssignmentExpr, Property, ObjectLiteral, CallExpr, MemberExpr, FunctionDeclaration, StringLiteral, IfStatement, ForStatement, TryCatchStatement, ArrayLiteral, ClassDeclarationStmt, ReturnStmt, NewExpr, WhileStmt, EnumDeclarationStmt, MatchExpr, ThrowStmt, BreakStmt, ContinueStmt } from "./ast";
 import { tokenize, Token, TokenType } from "./lexer";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,34 +3,59 @@ const begin = Date.now();
 
 import Parser from "./frontend/parser";
 
-import { createGlobalEnv } from "./runtime/environment";
+import { createGlobalEnv, rl } from "./runtime/environment";
 import { evaluate } from "./runtime/interpreter";
-import { readFileSync } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 import { get_currency, transcribe } from "./utils/transcriber";
 import { MK_STRING } from "./runtime/values";
 import { runtimeToJS } from "./runtime/eval/native-fns";
+import * as path from 'path';
+import * as readline from 'readline/promises';
+import { exit } from "process";
 
 const args = process.argv;
 args.shift();
 args.shift();
 const file = args.shift();
 
-if(file) {
-    run(file);
-} else {
-    repl();
-}
-
-async function run(filename: string) {
-
-    let input = readFileSync(filename, 'utf-8') + "\nfinishExit()";
+async function takeInput(file: string): Promise<string> {
+    let input = readFileSync(file, 'utf-8') + "\nfinishExit()";
     
     let currency = "-";
-    if (filename.endsWith('.bsx')) {
+    if (file.endsWith('.bsx')) {
         const currencies = JSON.parse(readFileSync(__dirname + "/../src/utils/currencies.json", "utf-8")); // should work for /src/ and /dist/
         currency = await get_currency(currencies);
         input = transcribe(input, currency);
     }
+
+    return input;
+}
+
+if (file=='view-ast' && args.length >= 1) { // Prints out the AST of the program
+    (async () => {
+        const file = await takeInput(args[0]);
+        const p = new Parser();
+        console.log(p.produceAST(file));
+    })();
+} else if (file=='unbeautify' && args.length >= 1) { // Transforms a .bsx file to a .bs file
+    (async () => {
+        const file = await takeInput(args[0]);
+        const parsedPath = path.parse(args[0]);
+        writeFileSync(path.format({
+            dir: parsedPath.dir,
+            name: parsedPath.name,
+            ext: ".bs",
+        }), file);
+    })();
+} else if (file) { // Execute file
+    run(file);
+} else { // Open REPL
+    repl();
+}
+
+async function run(filename: string) {
+    const input = await takeInput(filename);
+    let currency = await get_currency(JSON.parse(readFileSync(__dirname + "/../src/utils/currencies.json", "utf-8")));
 
     const parser = new Parser();
     const env = createGlobalEnv(args.includes("--time") ? begin : -1, filename.substring(0, filename.lastIndexOf("/") + 1), args.map(value => MK_STRING(value)), currency);
@@ -41,29 +66,40 @@ async function run(filename: string) {
 }
 
 async function repl() {
-    const readline = await import('readline/promises');
-
-    const parser = new Parser();
     const env = createGlobalEnv();
 
-    const rl = readline.createInterface({
-        input: process.stdin,
-        output: process.stdout
-    });
-
-    console.log("Repl v1.0 (Bussin)");
+    console.log("Repl v1.1 (Bussin)\nType 'rizz' into the console to change into Bussin X.");
+    let shittyLanguage = true;
 
     // eslint-disable-next-line no-constant-condition
     while(true) {
-        const input = await rl.question("> ");
-
-        const program = parser.produceAST(input);
-
         try {
-            const result = runtimeToJS(evaluate(program, env));
-            console.log(result);
-        } catch(err) {
-            console.log(err);
+            let input = await rl.question("> ");
+
+            if (input == 'rizz') {
+                console.clear();
+                console.log("Repl v69.420 (Bussin X)\nicl ts pmo sm n sb rn ngl, r u srsly srs n fr rn vro? lol atp js go b fr vro, idek nm, brb gng gtg atm Imao, bt ts pyo 2 js Imk lol onb fr nty b fr rn lk\n");
+                shittyLanguage = false;
+                continue;
+            }
+
+            if (!shittyLanguage) {
+                const currencies = JSON.parse(readFileSync(__dirname + "/../src/utils/currencies.json", "utf-8")); // should work for /src/ and /dist/
+                let currency = await get_currency(currencies);
+                input = transcribe(input, currency);
+            }
+
+            const program = (new Parser()).produceAST(input);
+
+            try {
+                const result = runtimeToJS(evaluate(program, env));
+                console.log(result);
+            } catch(err) {
+                console.log(err);
+            }
+        } catch (err) {
+            console.log(shittyLanguage ? '\nFarewell!' : '\nicl ts pmo 💔 lk atp js go');
+            exit(0);
         }
     }
 }

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -492,13 +492,19 @@ export function createGlobalEnv(beginTime: number = -1, filePath: string = __dir
     return env;
 }
 
+export enum ContinueType {
+    None=0,
+    Continue=1,
+    Break=2,
+}
+
 export default class Environment {
     private parent?: Environment;
     private variables: Map<string, RuntimeVal>
     private constants: Set<string>;
     public exitWith: RuntimeVal|null = null; // if we return, we set an exit value
     public canContinue: boolean = false;
-    public contin: number = 0; // 0 = none, 1 = continue, 2 = break
+    public contin: ContinueType = ContinueType.None; // 0 = none, 1 = continue, 2 = break
  
     constructor(parentENV?: Environment) {
         //const global = parentENV ? true : false;

--- a/src/runtime/environment.ts
+++ b/src/runtime/environment.ts
@@ -91,6 +91,15 @@ export function createGlobalEnv(beginTime: number = -1, filePath: string = __dir
         });
     }), true);
 
+    env.declareVar("push", MK_NATIVE_FN((args) => {
+        (args[0] as ArrayVal).values.push(args[1]);
+        return MK_NULL();
+    }), true);
+
+    env.declareVar("pop", MK_NATIVE_FN((args) => {
+        return (args[0] as ArrayVal).values.pop();
+    }), true);
+
     env.declareVar("math", MK_OBJECT(
         new Map()
             .set("pi", MK_NUMBER(Math.PI))
@@ -98,6 +107,21 @@ export function createGlobalEnv(beginTime: number = -1, filePath: string = __dir
             .set("sqrt", MK_NATIVE_FN((args) => {
                 const arg = (args[0] as NumberVal).value;
                 return MK_NUMBER(Math.sqrt(arg));
+            }))
+            .set("bor", MK_NATIVE_FN((args) => {
+                return MK_NUMBER((args[0] as NumberVal).value | (args[1] as NumberVal).value);
+            }))
+            .set("band", MK_NATIVE_FN((args) => {
+                return MK_NUMBER((args[0] as NumberVal).value & (args[1] as NumberVal).value);
+            }))
+            .set("bxor", MK_NATIVE_FN((args) => {
+                return MK_NUMBER((args[0] as NumberVal).value ^ (args[1] as NumberVal).value);
+            }))
+            .set("blsh", MK_NATIVE_FN((args) => {
+                return MK_NUMBER((args[0] as NumberVal).value << (args[1] as NumberVal).value);
+            }))
+            .set("brsh", MK_NATIVE_FN((args) => {
+                return MK_NUMBER((args[0] as NumberVal).value >> (args[1] as NumberVal).value);
             }))
             .set("random", MK_NATIVE_FN((args) => {
                 const arg1 = (args[0] as NumberVal).value;

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -1,9 +1,7 @@
-import { JsxEmit } from "typescript";
 import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, Identifier, MatchExpr, MemberExpr, NewExpr, ObjectLiteral } from "../../frontend/ast";
 import Environment from "../environment";
 import { evaluate } from "../interpreter";
 import { NumberVal, RuntimeVal, MK_NULL, ObjectVal, NativeFnValue, FunctionValue, BooleanVal, StringVal, NullVal, MK_NUMBER, MK_BOOL, ArrayVal, ClassFunctionValue, ClassValue, StaticClassValue, EnumValue } from "../values";
-import { match } from "assert";
 
 export function eval_numeric_binary_expr(lhs: RuntimeVal, rhs: RuntimeVal, operator: string): RuntimeVal {
 

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -1,7 +1,9 @@
-import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, Identifier, MemberExpr, ObjectLiteral } from "../../frontend/ast";
+import { JsxEmit } from "typescript";
+import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, Identifier, MatchExpr, MemberExpr, NewExpr, ObjectLiteral } from "../../frontend/ast";
 import Environment from "../environment";
 import { evaluate } from "../interpreter";
-import { NumberVal, RuntimeVal, MK_NULL, ObjectVal, NativeFnValue, FunctionValue, BooleanVal, StringVal, NullVal, MK_NUMBER, MK_BOOL, ArrayVal } from "../values";
+import { NumberVal, RuntimeVal, MK_NULL, ObjectVal, NativeFnValue, FunctionValue, BooleanVal, StringVal, NullVal, MK_NUMBER, MK_BOOL, ArrayVal, ClassFunctionValue, ClassValue, StaticClassValue, EnumValue } from "../values";
+import { match } from "assert";
 
 export function eval_numeric_binary_expr(lhs: RuntimeVal, rhs: RuntimeVal, operator: string): RuntimeVal {
 
@@ -119,6 +121,9 @@ export function eval_array_expr(obj: ArrayLiteral, env: Environment): RuntimeVal
 
 export function eval_function(func: FunctionValue, args: RuntimeVal[]): RuntimeVal {
     const scope = new Environment(func.declarationEnv);
+    if (func.type == 'class-function') {
+        scope.declareVar('this', (func as ClassFunctionValue).parent, false);
+    }
 
     // Create the variables for the parameters list
     for (let i = 0; i < func.parameters.length; i++) {
@@ -133,6 +138,100 @@ export function eval_function(func: FunctionValue, args: RuntimeVal[]): RuntimeV
     // Evaluate the function body line by line
     for (const stmt of func.body) {
         result = evaluate(stmt, scope);
+        if (scope.exitWith != null) {
+            result = scope.exitWith;
+            break;
+        }
+    }
+
+    scope.exitWith = null;
+    return result;
+}
+
+export function eval_new_expr(expr: NewExpr, env: Environment): RuntimeVal {
+    const _target = evaluate(expr.target, env);
+    if (_target.type != 'static-class') {
+        throw `Can only instantiate static classes (got ${_target.type})`;
+    }
+    const target = _target as StaticClassValue;
+    const fields = new Map();
+    target.fields.forEach((v, k) => {
+        fields.set(k, MK_NULL());
+    });
+
+    const base = {
+        type: "class",
+        parent: target,
+        fields,
+        funs: new Map(),
+    } as ClassValue;
+
+    target.funs.forEach((v,k) => {
+        v.parent = base;
+        base.funs.set(k, v);
+    });
+
+    if (base.funs.has('constructor')) {
+        eval_function(base.funs.get('constructor') as ClassFunctionValue, expr.args.map(arg => evaluate(arg, env)));
+    }
+
+    return base;
+}
+
+export function eval_match_expr(expr: MatchExpr, env: Environment): RuntimeVal {
+    const scope = new Environment(env);
+    let matchee = evaluate(expr.value, scope);
+    let matchee_str = JSON.stringify(matchee);
+    let result: RuntimeVal = MK_NULL();
+    let matched = false;
+
+    expr.cases.forEach((v,k) => {
+        if (matched) {
+            return;
+        }
+
+        let dst_var = undefined;
+
+        for (const key of k) {
+            if (key.kind == 'CallExpr' && (key as CallExpr).args.length == 1 && (key as CallExpr).args[0].kind == 'Identifier') { // Potential Enum.Tagged(var) syntax
+                const left = evaluate((key as CallExpr).caller, scope);
+                if (left.type == 'enum' && matchee.type == 'enum' && (matchee as EnumValue).tagged != undefined) {
+                    dst_var = ((key as CallExpr).args[0] as Identifier).symbol;
+                    matched = true;
+                    break;
+                }
+                continue;
+            }
+            // Normal enum matching will match on the matchee string :)
+            const val = evaluate(key, scope);
+            if (JSON.stringify(val) == matchee_str) {
+                matched = true;
+                break;
+            }
+        }
+        
+        if (matched) {
+            if (dst_var != undefined) {
+                scope.declareVar(dst_var, (matchee as EnumValue).tagged, false);
+            }
+            for (const stmt of v) {
+                result = evaluate(stmt, scope);
+                if (scope.exitWith != null) {
+                    result = scope.exitWith;
+                    break;
+                }
+            }
+        }
+    });
+
+    if ((!matched) && expr.defaultCase != undefined) {
+        for (const stmt of expr.defaultCase) {
+            result = evaluate(stmt, scope);
+            if (scope.exitWith != null) {
+                result = scope.exitWith;
+                break;
+            }
+        }
     }
 
     return result;
@@ -143,17 +242,26 @@ export function eval_call_expr(expr: CallExpr, env: Environment): RuntimeVal {
     const fn = evaluate(expr.caller, env);
 
     if(fn != null) {
-        if (fn.type == "native-fn") {
-            return (fn as NativeFnValue).call(args, env);
-        }
-
-        if (fn.type == "fn") {
-            const func = fn as FunctionValue;
-            return eval_function(func, args);
+        switch (fn.type) {
+            case 'native-fn':
+                return (fn as NativeFnValue).call(args, env);
+            case 'fn':
+            case 'class-function': {
+                const func = fn as FunctionValue;
+                return eval_function(func, args);
+            }
+            case 'enum': {
+                if (args.length != 1) {
+                    throw `Tagging an enum requires one argument in the call expression, but got ${args.length} arguments.`;
+                }
+                const clone: EnumValue = {...(fn as EnumValue)};
+                clone.tagged = args[0];
+                return clone;
+            }
+            default:
+                throw "Cannot call value that is not a function or enum: " + JSON.stringify(fn);
         }
     }
-
-    throw "Cannot call value that is not a function: " + JSON.stringify(fn);
 }
 
 export function eval_member_expr(env: Environment, node?: AssignmentExpr, expr?: MemberExpr): RuntimeVal {

--- a/src/runtime/eval/expressions.ts
+++ b/src/runtime/eval/expressions.ts
@@ -256,10 +256,10 @@ export function eval_call_expr(expr: CallExpr, env: Environment): RuntimeVal {
                 clone.tagged = args[0];
                 return clone;
             }
-            default:
-                throw "Cannot call value that is not a function or enum: " + JSON.stringify(fn);
         }
     }
+
+    throw "Cannot call value that is not a function or enum: " + JSON.stringify(fn);
 }
 
 export function eval_member_expr(env: Environment, node?: AssignmentExpr, expr?: MemberExpr): RuntimeVal {

--- a/src/runtime/eval/native-fns.ts
+++ b/src/runtime/eval/native-fns.ts
@@ -1,4 +1,4 @@
-import { RuntimeVal, StringVal, NumberVal, BooleanVal, NullVal, ObjectVal, FunctionValue, ArrayVal, MK_NULL, MK_BOOL, MK_NUMBER, MK_OBJECT, MK_STRING, MK_ARRAY } from '../values'
+import { RuntimeVal, StringVal, NumberVal, BooleanVal, NullVal, ObjectVal, FunctionValue, ArrayVal, MK_NULL, MK_BOOL, MK_NUMBER, MK_OBJECT, MK_STRING, MK_ARRAY, ClassValue, StaticClassValue, ClassFunctionValue, EnumValue, StaticEnumValue } from '../values'
 
 export function printValues(args: Array<RuntimeVal>) {
     for (let i = 0; i < args.length; i++) {
@@ -8,7 +8,7 @@ export function printValues(args: Array<RuntimeVal>) {
     }
 }
 
-export function runtimeToJS(arg: RuntimeVal) {
+export function runtimeToJS(arg: RuntimeVal): any {
     switch (arg.type) {
         case "string":
             return (arg as StringVal).value;
@@ -36,6 +36,22 @@ export function runtimeToJS(arg: RuntimeVal) {
         }
         case "native-fn": {
             return `[Native Function]`;
+        }
+        case 'class': {
+            return `[Class Instance: ${(arg as ClassValue).parent.name}]`;
+        }
+        case 'static-class': {
+            return `[Class: ${(arg as StaticClassValue).name}]`;
+        }
+        case 'class-function': {
+            return `[Class Method: ${(arg as ClassFunctionValue).name}]`;
+        }
+        case 'enum': {
+            const en = arg as EnumValue;
+            return `${en.parent.name}.${en.name}${en.tagged==null?'':'('+runtimeToJS(en.tagged)+')'}`
+        }
+        case 'static-enum': {
+            return `[Enum: ${(arg as StaticEnumValue).name}]`;
         }
         default:
             return arg;

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -1,6 +1,6 @@
 import { MK_NULL, NumberVal, RuntimeVal, StringVal } from "./values";
 import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, ClassDeclarationStmt, EnumDeclarationStmt, ForStatement, FunctionDeclaration, Identifier, IfStatement, MatchExpr, MemberExpr, NewExpr, NumericLiteral, ObjectLiteral, Program, ReturnStmt, Stmt, StringLiteral, ThrowStmt, TryCatchStatement, VarDeclaration, WhileStmt } from "../frontend/ast";
-import Environment from "./environment"
+import Environment, { ContinueType } from "./environment"
 import { eval_function_declaration, eval_program, eval_val_declaration, eval_if_statement, eval_for_statement, eval_try_catch_statement, eval_class_declaration, eval_enum_declaration, eval_while_statement } from "./eval/statements";
 import { eval_identifier, eval_binary_expr, eval_assignment, eval_object_expr, eval_call_expr, eval_member_expr, eval_array_expr, eval_new_expr, eval_match_expr } from "./eval/expressions"
 import { ClassDeclaration, ReturnStatement, ThrowStatement, WhileStatement } from "typescript";
@@ -63,14 +63,14 @@ export function evaluate(astNode: Stmt, env: Environment): RuntimeVal {
             if (!env.canContinue) {
                 throw "Can only break in while and for loops.";
             }
-            env.contin = 2;
+            env.contin = ContinueType.Break;
             return MK_NULL();
         }
         case "ContinueStatement": {
             if (!env.canContinue) {
                 throw "Can only continue in while and for loops.";
             }
-            env.contin = 1;
+            env.contin = ContinueType.Continue;
             return MK_NULL();
         }
         default:

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -1,8 +1,9 @@
-import { NumberVal, RuntimeVal, StringVal } from "./values";
-import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, ForStatement, FunctionDeclaration, Identifier, IfStatement, MemberExpr, NumericLiteral, ObjectLiteral, Program, Stmt, StringLiteral, TryCatchStatement, VarDeclaration } from "../frontend/ast";
+import { MK_NULL, NumberVal, RuntimeVal, StringVal } from "./values";
+import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, ClassDeclarationStmt, EnumDeclarationStmt, ForStatement, FunctionDeclaration, Identifier, IfStatement, MatchExpr, MemberExpr, NewExpr, NumericLiteral, ObjectLiteral, Program, ReturnStmt, Stmt, StringLiteral, ThrowStmt, TryCatchStatement, VarDeclaration } from "../frontend/ast";
 import Environment from "./environment"
-import { eval_function_declaration, eval_program, eval_val_declaration, eval_if_statement, eval_for_statement, eval_try_catch_statement } from "./eval/statements";
-import { eval_identifier, eval_binary_expr, eval_assignment, eval_object_expr, eval_call_expr, eval_member_expr, eval_array_expr } from "./eval/expressions"
+import { eval_function_declaration, eval_program, eval_val_declaration, eval_if_statement, eval_for_statement, eval_try_catch_statement, eval_class_declaration, eval_enum_declaration } from "./eval/statements";
+import { eval_identifier, eval_binary_expr, eval_assignment, eval_object_expr, eval_call_expr, eval_member_expr, eval_array_expr, eval_new_expr, eval_match_expr } from "./eval/expressions"
+import { ClassDeclaration, ReturnStatement, ThrowStatement } from "typescript";
 
 
 export function evaluate(astNode: Stmt, env: Environment): RuntimeVal {
@@ -34,13 +35,42 @@ export function evaluate(astNode: Stmt, env: Environment): RuntimeVal {
             return eval_member_expr(env, undefined, astNode as MemberExpr);
         case "TryCatchStatement":
             return eval_try_catch_statement(env, astNode as TryCatchStatement);
+        case "NewExpr":
+            return eval_new_expr(astNode as NewExpr, env);
+        case "MatchExpr":
+            return eval_match_expr(astNode as MatchExpr, env);
 
         // Handle statements
         case "VarDeclaration":
             return eval_val_declaration(astNode as VarDeclaration, env);
         case "FunctionDeclaration":
             return eval_function_declaration(astNode as FunctionDeclaration, env);
-            
+        case "ThrowStatement": {
+            throw evaluate((astNode as ThrowStmt).value, env);
+        }
+        case "ReturnStatement": {
+            const value = evaluate((astNode as ReturnStmt).value, env);
+            env.exitWith = value;
+            return value;
+        }
+        case "ClassDeclaration":
+            return eval_class_declaration(astNode as ClassDeclarationStmt, env);
+        case "EnumDeclaration":
+            return eval_enum_declaration(astNode as EnumDeclarationStmt, env);
+        case "BreakStatement": {
+            if (!env.canContinue) {
+                throw "Can only break in while and for loops.";
+            }
+            env.contin = 2;
+            return MK_NULL();
+        }
+        case "ContinueStatement": {
+            if (!env.canContinue) {
+                throw "Can only continue in while and for loops.";
+            }
+            env.contin = 1;
+            return MK_NULL();
+        }
         default:
             console.error("This AST node has not yet been setup for interpretation", astNode);
             process.exit(0)

--- a/src/runtime/interpreter.ts
+++ b/src/runtime/interpreter.ts
@@ -1,9 +1,9 @@
 import { MK_NULL, NumberVal, RuntimeVal, StringVal } from "./values";
-import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, ClassDeclarationStmt, EnumDeclarationStmt, ForStatement, FunctionDeclaration, Identifier, IfStatement, MatchExpr, MemberExpr, NewExpr, NumericLiteral, ObjectLiteral, Program, ReturnStmt, Stmt, StringLiteral, ThrowStmt, TryCatchStatement, VarDeclaration } from "../frontend/ast";
+import { ArrayLiteral, AssignmentExpr, BinaryExpr, CallExpr, ClassDeclarationStmt, EnumDeclarationStmt, ForStatement, FunctionDeclaration, Identifier, IfStatement, MatchExpr, MemberExpr, NewExpr, NumericLiteral, ObjectLiteral, Program, ReturnStmt, Stmt, StringLiteral, ThrowStmt, TryCatchStatement, VarDeclaration, WhileStmt } from "../frontend/ast";
 import Environment from "./environment"
-import { eval_function_declaration, eval_program, eval_val_declaration, eval_if_statement, eval_for_statement, eval_try_catch_statement, eval_class_declaration, eval_enum_declaration } from "./eval/statements";
+import { eval_function_declaration, eval_program, eval_val_declaration, eval_if_statement, eval_for_statement, eval_try_catch_statement, eval_class_declaration, eval_enum_declaration, eval_while_statement } from "./eval/statements";
 import { eval_identifier, eval_binary_expr, eval_assignment, eval_object_expr, eval_call_expr, eval_member_expr, eval_array_expr, eval_new_expr, eval_match_expr } from "./eval/expressions"
-import { ClassDeclaration, ReturnStatement, ThrowStatement } from "typescript";
+import { ClassDeclaration, ReturnStatement, ThrowStatement, WhileStatement } from "typescript";
 
 
 export function evaluate(astNode: Stmt, env: Environment): RuntimeVal {
@@ -56,7 +56,9 @@ export function evaluate(astNode: Stmt, env: Environment): RuntimeVal {
         case "ClassDeclaration":
             return eval_class_declaration(astNode as ClassDeclarationStmt, env);
         case "EnumDeclaration":
-            return eval_enum_declaration(astNode as EnumDeclarationStmt, env);
+            return eval_enum_declaration(astNode as EnumDeclarationStmt, env)
+        case "WhileStatement":
+            return eval_while_statement(astNode as WhileStmt, env);
         case "BreakStatement": {
             if (!env.canContinue) {
                 throw "Can only break in while and for loops.";

--- a/src/runtime/values.ts
+++ b/src/runtime/values.ts
@@ -1,10 +1,58 @@
 import { Stmt } from "../frontend/ast";
 import Environment from "./environment";
 
-export type ValueType = "null" | "number" | "boolean" | "object" | "native-fn" | "fn" | "string" | "array";
+export type ValueType = 
+    "null" |
+    "number" |
+    "boolean" |
+    "object" |
+    "native-fn" |
+    "fn" |
+    "string" |
+    "array" |
+    "class" |
+    "static-class" | 
+    "class-function" |
+    "static-enum" |
+    "enum"
+;
 
 export interface RuntimeVal {
     type: ValueType;
+}
+
+export interface StaticEnumValue extends RuntimeVal {
+    type: "static-enum";
+    name: string;
+    members: string[];
+}
+
+export interface EnumValue extends RuntimeVal {
+    type: "enum";
+    name: string;
+    parent: StaticEnumValue;
+    tagged?: RuntimeVal;
+}
+
+export interface ClassFunctionValue extends FunctionValue {
+    type: "class-function";
+    parent: ClassValue|StaticClassValue;
+}
+
+export interface StaticClassValue extends RuntimeVal {
+    type: "static-class";
+    name: string;
+    fields: Set<string>;
+    staticFields: Map<string, RuntimeVal>;
+    funs: Map<string, ClassFunctionValue>;
+    staticFuns: Map<string, ClassFunctionValue>;
+}
+
+export interface ClassValue extends RuntimeVal {
+    type: "class";
+    parent: StaticClassValue;
+    fields: Map<string, RuntimeVal>;
+    funs: Map<string, ClassFunctionValue>;
 }
 
 export interface NullVal extends RuntimeVal {
@@ -39,7 +87,7 @@ export interface ArrayVal extends RuntimeVal {
 
 
 export interface FunctionValue extends RuntimeVal {
-    type: "fn";
+    type: "fn"|"class-function";
     name: string;
     parameters: string[];
     declarationEnv: Environment;

--- a/src/utils/transcriber.ts
+++ b/src/utils/transcriber.ts
@@ -61,6 +61,20 @@ async function get_country() {
 export function transcribe(code: string, currency: string) {
     return code
         // @ts-expect-error replace_fr is assigned earlier in the code.
+        .replace_fr("chad", "class")
+        .replace_fr("drake", "this")
+        .replace_fr("ghost", "return")
+        .replace_fr("aura", "break")
+        .replace_fr("gyatt", "continue")
+        .replace_fr("diddy", "while")
+        .replace_fr("kai cenat", "static")
+        .replace_fr("skibidi toilet", "constructor")
+        .replace_fr("mog", "new")
+        .replace_fr("baller", "enum")
+        .replace_fr("fw", "match")
+        .replace_fr("edges", "=>")
+        .replace_fr("put the fries in the bag lil bro", "default")
+        .replace_fr("yeet", "throw")
         .replace_fr(";", '!')
         .replace_fr("rn", ';')
         .replace_fr("be", '=')
@@ -81,8 +95,10 @@ export function transcribe(code: string, currency: string) {
         .replace_fr("thicc", '>')
         .replace_fr("nocap", 'true')
         .replace_fr("cap", 'false')
-        .replace_fr("fuck_around", 'try')
-        .replace_fr("find_out", 'catch')
+        .replace_fr("fuck around", 'try')
+        .replace_fr("find out", 'catch')
+        .replace_fr("fuck_around", 'try') // These are still here to
+        .replace_fr("find_out", 'catch')  // preserve legacy code.
         .replace_fr("clapback", 'exec')
         .replace_fr("yap", 'input')
         .replace_fr("minus", "-")


### PR DESCRIPTION
# Description
I was bored one day and made these changes in 2 or 3 hours.
I've made numerous interpreters with implementation exactly like this as well as compilers and bytecode interpreters, so this was a breeze.
I'm surprised that some of the features I added weren't here in the first place.
# Main Changes:
* Add classes
Now, you can declare classes with the `class` or `chad` keyword!
Here's an example I wrote:
``` rs
class Apple {
    static class_name = "Apple";
    percent;

    constructor() {
        this.percent = 100;
    }

    eat() {
        this.percent -= 1;
    }
}

println(Apple.class_name);

let myApple = new Apple();
myApple.eat();
println(myApple.percent);
```
```
Apple
99
```
Of course, there's Bussin X syntax to this as well.
* Add while loops
This one's easy enough to understand. We have while loops with the `while` keyword!
* Add enums
Enums can be declared with the `enum` keyword.
You can use the `Enum.Name` syntax to make an enum.
Tagged enums also work with the `Enum.Name(Value)` syntax. You match on them like so:
```rs
enum Foo {}
match Foo.Bar(3) {
   Foo.Bar(n) => { println(n) }
}
```
```
3
```
* Add pattern matching
As shown above, you can use the `match` keyword with a Rust-like syntax. Matching on multiple members is done by separating them with commas.
Use the default keyword to match the default case.
You can match on *anything* thanks to the interpreter comparing cases by `JSON.stringify()`.
* Add error throwing
Another simple one: use the `throw <expression>` syntax to throw errors. You can try and catch on them like normal.
* Add function returning
I got the idea from #63; though, I'm not too sure why we never had function returning in the first place.
In reality, it was just a simple trick that stores a return value in the Environment and Environments can carry over return values in things like if statements.
* Add breaking and continuing from loops
The approach to this one was very similar to the one with function returns: there's just two variables in the Environment that signifies if you can continue/break and whether or not you're continuing or breaking from the loop.
# Misc. Changes:
* Add `push<T>(arr: T[], val: T)` and `pop<T>(arr: T[]): T` functions
* Add math.bor, math.band, math.bxor, math.blsh, and math.brsh functions
* Semicolons at the end of expressions
In the unfortunate scenario of ambiguous syntax, you can include semicolons at the end of expressions. This also means that the `rn` keyword can be put in places that make sense.
* Fixed character duplication glitch in REPL due to multiple Readline creations (now there's one global Readline)
* Updated REPL version and added support for switching to Bussin X syntax within the REPL
* README Updates
I added a table of contents (as there's way too much stuff to shuffle through) and updated the new section. I also took the time to write some minor documentation for the things I added in the style of how it has been previously done.
* Add support for keywords with spaces in the transcriber
This means that the `fuck_with` keyword can now be the `fuck with` keyword. I still kept the original keywords to make sure legacy code is supported.
* I added a few more examples in the examples folder to test out classes, enums, and function returns.
* You can view the AST of a program with the `[...] view-ast [file]` usage.
* You can transform a .bsx file to a .bs file with the `[...] unbeautify [file]` usage.
# New Transcriber Keyword Additions
Not the greatest at slang, I just kind of Googled a list of brainrot words and occasionally chose a word that actually made sense.
| Bussin Keyword 👎 | Bussin X Keyword 🚀 |
| ------ | -------- |
| class | chad |
| this | drake |
| return | ghost |
| break | aura |
| gyatt | continue |
| while | diddy |
| static | kai cenat |
| constructor | skibidi toilet |
| new | mog |
| enum | baller |
| match | fw |
| => | edges |
| default | put the fries in the bag lil bro |
| throw | yeet |
| try | fuck around |
| catch | find out |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for classes, enums, pattern matching, error throwing, while loops, function returns, and loop control keywords.
	- Added new CLI commands to view the AST of a file and to convert `.bsx` files to `.bs` files.
	- Enhanced REPL with a new language toggle and stylized prompts.

- **Bug Fixes**
	- Corrected language keyword handling in example code and documentation.

- **Documentation**
	- Expanded and reorganized the README with detailed instructions, new features, and a comprehensive Table of Contents.
	- Added examples and clarified syntax for new language constructs.

- **Chores**
	- Updated and added development dependencies for improved tooling and type support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->